### PR TITLE
Fixduplicates

### DIFF
--- a/src/core/cosmopolite.scala
+++ b/src/core/cosmopolite.scala
@@ -39,6 +39,9 @@ case class Messages[L <: String](text: Map[String, String]):
    def apply[L2 <: L: ValueOf]: String = text(summon[ValueOf[L2]].value)
    def apply[L2 <: L]()(using ctx: Language[L2]): String = text(ctx.value)
 
+   // Narrows type to the subset of Languages L2 in L
+   def subset[L2 <: L]: Messages[L2] = Messages[L2](text)
+
 import languages.common._
 extension (ctx: StringContext)
    def en(msgs: Messages[? >: En]*): Messages[En] = Messages.make[En](ctx.parts, msgs)

--- a/src/core/cosmopolite.scala
+++ b/src/core/cosmopolite.scala
@@ -33,7 +33,7 @@ object Messages:
       Messages[L](Map(summon[ValueOf[L]].value -> string))
 
 case class Messages[L <: String](text: Map[String, String]):
-   def &[L2 <: String](messages: Messages[L2])(using NotGiven[(L | L2) =:= L]): Messages[L | L2] =
+   def &[L2 <: String](messages: Messages[L2])(using NotGiven[L2 <:< L]): Messages[L | L2] =
       Messages(text ++ messages.text)
    
    def apply[L2 <: L: ValueOf]: String = text(summon[ValueOf[L2]].value)

--- a/src/examples/example.scala
+++ b/src/examples/example.scala
@@ -20,6 +20,8 @@ def run(lang: String): Unit =
       es"Es ${number(1)} en español" &
       fr"C'est ${number(1)} en français"
 
+   val subset: Messages[Ru & Es] = msg.subset[Ru & Es]
+
    Language.parse[MyLangs](lang).foreach { lang =>
       given Language[MyLangs] = lang
       println(msg())

--- a/src/examples/example.scala
+++ b/src/examples/example.scala
@@ -10,7 +10,7 @@ var dynamicLang = "es"
 @main
 def run(lang: String): Unit =
    def number(n: Int): Messages[MyLangs] = n match
-      case 1 => en"one" & fr"un" & de"ein" & es"uno"
+      case 1 => en"one" & fr"un" & de"ein" & es"uno" // & fr"uno" // KO
       case 2 => en"two" & fr"deux" & de"zwei" & es"dos"
       case 3 => en"three" & fr"trois" & de"drei" & es"tres"
 


### PR DESCRIPTION
Fixes bug in & constraint, doesn't forbid repeated application with duplicated language.
Also added a commit to add a simple narrow method, that way it can be easily retyped to
a subset of the languages, perhaps with an implicit conversion if we want to make it more
transparent to the user.