### PR TITLE
Reify to list

### DIFF
--- a/src/core/cosmopolite.scala
+++ b/src/core/cosmopolite.scala
@@ -11,18 +11,20 @@ object Language:
    @targetName("make")
    def apply[L <: String: ValueOf]: Language[L] = new Language(summon[ValueOf[L]].value)
    
-   inline def parse[L <: String](str: String): Option[Language[L]] = ${doParse[L]('str)}
+   inline def parse[L <: String](str: String): Option[Language[L]] =
+      Option.when(reifyToList[L].contains(str))(Language(str))
 
-   private def doParse[L <: String: Type](str: Expr[String])(using quotes: Quotes): Expr[Option[Language[L]]] =
+   inline def reifyToList[L <: String]: List[String] = ${reifyToListMacro[L]}
+
+   private def reifyToListMacro[L <: String: Type](using quotes: Quotes): Expr[List[String]] =
       import quotes.reflect._
 
       def langs(t: TypeRepr): List[String] = t.dealias match
          case OrType(left, right) => langs(left) ++ langs(right)
+         case AndType(left, right) => langs(left) ++ langs(right)
          case ConstantType(StringConstant(lang)) => List(lang)
 
-      langs(TypeRepr.of[L]).foldLeft('{ None: Option[Language[L]] }) { (agg, lang) =>
-         '{ if $str == ${Expr(lang)} then Some(Language[L](${Expr(lang)})) else $agg }
-      }
+      Expr(langs(TypeRepr.of[L]))
 
 object Messages:
    def apply[L <: String: ValueOf](seq: Seq[String], parts: Seq[Messages[? >: L]]): Messages[L] =

--- a/src/core/cosmopolite.scala
+++ b/src/core/cosmopolite.scala
@@ -12,17 +12,16 @@ object Language:
    def apply[L <: String: ValueOf]: Language[L] = new Language(summon[ValueOf[L]].value)
    
    inline def parse[L <: String](str: String): Option[Language[L]] =
-      Option.when(reifyToList[L].contains(str))(Language(str))
+      Option.when(reifyToSet[L].contains(str))(Language(str))
 
-   inline def reifyToList[L <: String]: List[String] = ${reifyToListMacro[L]}
+   private inline def reifyToSet[L <: String]: Set[String] = ${reifyToSetMacro[L]}
 
-   private def reifyToListMacro[L <: String: Type](using quotes: Quotes): Expr[List[String]] =
+   private def reifyToSetMacro[L <: String: Type](using quotes: Quotes): Expr[Set[String]] =
       import quotes.reflect._
 
-      def langs(t: TypeRepr): List[String] = t.dealias match
+      def langs(t: TypeRepr): Set[String] = t.dealias match
          case OrType(left, right) => langs(left) ++ langs(right)
-         case AndType(left, right) => langs(left) ++ langs(right)
-         case ConstantType(StringConstant(lang)) => List(lang)
+         case ConstantType(StringConstant(lang)) => Set(lang)
 
       Expr(langs(TypeRepr.of[L]))
 


### PR DESCRIPTION
Modularize the parse macro to use another macro that reifies composite languages type into a list of string or languages.
It could be useful for other purposes that use the composite type, e.g. create a new I18n with just the new type, not narrowing the type but extracting those elements.
 
It includes the challenge of how to turn the `List[String]` return into `List[_ <: L]` I couldn't see how to prove that as the matching is for the `StringConstant`, and that is not parameterised so we lose that proof that is guaranteed by the decomposition. A cast should be needed probably.
